### PR TITLE
Fix ComponentHolder::setWidth setting the component's height

### DIFF
--- a/common/src/main/java/io/github/kurrycat/mpkmod/gui/components/ComponentHolder.java
+++ b/common/src/main/java/io/github/kurrycat/mpkmod/gui/components/ComponentHolder.java
@@ -174,9 +174,9 @@ public abstract class ComponentHolder {
     }
 
     public void setWidth(double w, boolean percent) {
-        if (this.size.getY() == w && percent == PERCENT.HAS_SIZE_X(percentFlag)) return;
+        if (this.size.getX() == w && percent == PERCENT.HAS_SIZE_X(percentFlag)) return;
         percentFlag = PERCENT.SET_SIZE_X(percentFlag, percent);
-        this.size.setY(PERCENT.HAS_SIZE_Y(percentFlag) ? MathUtil.constrain01(w) : w);
+        this.size.setX(PERCENT.HAS_SIZE_X(percentFlag) ? MathUtil.constrain01(w) : w);
         updatePosAndSize();
     }
 


### PR DESCRIPTION
Fixes the `ComponentHolder::setWidth` method to set the width as expected instead of the height.

Fixes #18